### PR TITLE
fix: pre-release corrections for v1.0.0

### DIFF
--- a/vm/guest/demo-config.sh
+++ b/vm/guest/demo-config.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Apply demo configuration to the Task Manager Colors plasmoid
+# Pre-assigns colors to the 8 apps launched by setup-vm.sh
+#
+# Usage: bash demo-config.sh
+# Called by: setup-vm.sh (via serial console, runs as root)
+#
+# Requires: plasmoid already added to panel (add-to-panel.sh)
+
+set -euo pipefail
+
+PLUGIN_ID="com.comexpertise.plasma.taskmanagercolors"
+CONFIG_FILE="/home/neon/.config/plasma-org.kde.plasma.desktop-appletsrc"
+
+# ── Find the applet's config group ──────────────────────────────
+# The config file has INI-style sections like:
+#   [Containments][2][Applets][15]
+#   plugin=com.comexpertise.plasma.taskmanagercolors
+# We need the group path segments to build kwriteconfig6 --group flags.
+
+find_applet_group() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "ERROR: Config file not found: $CONFIG_FILE" >&2
+        return 1
+    fi
+
+    local current_group=""
+    while IFS= read -r line; do
+        # Track current INI group
+        if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+            current_group="${BASH_REMATCH[1]}"
+        fi
+        # Look for our plugin ID
+        if [[ "$line" == "plugin=$PLUGIN_ID" ]] && [[ -n "$current_group" ]]; then
+            echo "$current_group"
+            return 0
+        fi
+    done < "$CONFIG_FILE"
+
+    echo "ERROR: Applet $PLUGIN_ID not found in $CONFIG_FILE" >&2
+    return 1
+}
+
+echo "  Finding plasmoid config group..."
+APPLET_GROUP=$(find_applet_group)
+
+echo "  Applet group: [$APPLET_GROUP]"
+
+# Build --group flags for kwriteconfig6
+# Input: "Containments][2][Applets][15" → segments: Containments, 2, Applets, 15
+# We append Configuration and General for the config subgroup
+build_group_flags() {
+    local group_str="$1"
+    local flags=()
+    # Split on "][" to get individual group segments
+    IFS=']' read -ra parts <<< "$group_str"
+    for part in "${parts[@]}"; do
+        # Remove leading "["
+        part="${part#\[}"
+        if [ -n "$part" ]; then
+            flags+=("--group" "$part")
+        fi
+    done
+    # Append Configuration/General subgroup
+    flags+=("--group" "Configuration" "--group" "General")
+    echo "${flags[@]}"
+}
+
+GROUP_FLAGS=$(build_group_flags "$APPLET_GROUP")
+
+# Helper: write a config key using kwriteconfig6
+write_config() {
+    local key="$1"
+    local value="$2"
+    # shellcheck disable=SC2086
+    kwriteconfig6 --file "$CONFIG_FILE" $GROUP_FLAGS --key "$key" "$value"
+}
+
+# ── Demo color palette ──────────────────────────────────────────
+# Harmonious colors assigned to each app, Nyan Cat on Konsole
+#
+# Format: "appId": "#rrggbb" or "appId": "#rrggbb:nyan"
+# See CLAUDE.md for appColorMap JSON-in-String format
+
+APP_COLOR_MAP='{
+  "org.kde.dolphin": "#2196F3",
+  "systemsettings": "#9C27B0",
+  "org.kde.kate": "#4CAF50",
+  "org.kde.konsole": "#FF5722:nyan",
+  "org.kde.discover": "#FF9800",
+  "org.kde.gwenview": "#00BCD4",
+  "org.kde.okular": "#F44336",
+  "org.kde.kinfocenter": "#607D8B"
+}'
+
+# Compact JSON (single line, no whitespace) for KConfig storage
+APP_COLOR_MAP_COMPACT=$(echo "$APP_COLOR_MAP" | tr -d '\n' | sed 's/  *//g')
+
+# ── Write config values ─────────────────────────────────────────
+
+echo "  Writing demo configuration..."
+
+write_config "appColorMap" "$APP_COLOR_MAP_COMPACT"
+write_config "colorMode" "background"
+write_config "backgroundOpacity" "0.55"
+write_config "isEnabled" "true"
+write_config "rainbowStyle" "wave"
+write_config "rainbowSpeed" "3.0"
+
+echo "  Demo config applied:"
+echo "    - 8 apps with assigned colors"
+echo "    - Nyan Cat enabled on Konsole"
+echo "    - Display mode: background (55% opacity)"
+echo "    - Rainbow style: wave"

--- a/vm/guest/setup-vm.sh
+++ b/vm/guest/setup-vm.sh
@@ -6,6 +6,14 @@
 
 set -euo pipefail
 
+DEMO_CONFIG="${DEMO_CONFIG:-false}"
+
+if [ "$DEMO_CONFIG" = "true" ]; then
+    TOTAL_STEPS=5
+else
+    TOTAL_STEPS=4
+fi
+
 echo "=== Task Manager Colors — VM Setup ==="
 
 # Stop serial getty if present (prevents competing with serial-shell for ttyS0)
@@ -18,7 +26,7 @@ run_as_neon() {
 }
 
 # 1. Mount shared folder (may already be mounted by bootstrap)
-echo "[1/4] Mounting shared folder..."
+echo "[1/$TOTAL_STEPS] Mounting shared folder..."
 mkdir -p /mnt/plasmoid
 if mountpoint -q /mnt/plasmoid; then
     echo "  OK: /mnt/plasmoid already mounted"
@@ -29,18 +37,18 @@ ls /mnt/plasmoid/metadata.json >/dev/null 2>&1 || { echo "ERROR: shared folder m
 echo "  OK: /mnt/plasmoid verified"
 
 # 2. Install plasmoid (as neon user)
-echo "[2/4] Installing plasmoid..."
+echo "[2/$TOTAL_STEPS] Installing plasmoid..."
 run_as_neon "kpackagetool6 -t Plasma/Applet -r com.comexpertise.plasma.taskmanagercolors 2>/dev/null || true"
 run_as_neon "kpackagetool6 -t Plasma/Applet -i /mnt/plasmoid"
 echo "  OK: plasmoid installed"
 
 # 3. Add widget to panel via Plasma scripting API (as neon user)
-echo "[3/4] Adding widget to panel..."
+echo "[3/$TOTAL_STEPS] Adding widget to panel..."
 bash /mnt/plasmoid/vm/guest/add-to-panel.sh
 echo "  OK: widget added to panel"
 
 # 4. Open test apps to populate the task manager
-echo "[4/4] Opening test apps..."
+echo "[4/$TOTAL_STEPS] Opening test apps..."
 run_as_neon "dolphin ~ &>/dev/null &"
 sleep 1
 run_as_neon "systemsettings &>/dev/null &"
@@ -57,8 +65,20 @@ run_as_neon "okular &>/dev/null &"
 sleep 1
 run_as_neon "kinfocenter &>/dev/null &"
 
+# 5. Apply demo configuration (optional)
+if [ "$DEMO_CONFIG" = "true" ]; then
+    echo "[5/$TOTAL_STEPS] Applying demo configuration..."
+    bash /mnt/plasmoid/vm/guest/demo-config.sh
+    echo "  OK: demo config applied"
+fi
+
 echo ""
 echo "=== Setup complete! ==="
 echo "  - 8 apps launched: Dolphin, System Settings, Kate, Konsole, Discover, Gwenview, Okular, Info Center"
+if [ "$DEMO_CONFIG" = "true" ]; then
+    echo "  - Demo config applied: colors assigned, Nyan Cat on Konsole"
+else
+    echo "  - Use DEMO_CONFIG=true to pre-assign colors for screenshots"
+fi
 echo "  - Click the widget icon in the panel to see the popup"
 echo "  - Reload after code changes: ./vm/reload-plasmoid.sh"


### PR DESCRIPTION
## Summary

Pre-release fixes and additions before publishing v1.0.0 to the KDE Store.

- Fix license (GPL-2.0-or-later) and repo URL in README
- Add custom SVG icons (panel icon + store logo) with Breeze guidelines compliance
- Add copyright notice to README
- Expand VM test apps to 8 (Dolphin, System Settings, Kate, Konsole, Discover, Gwenview, Okular, Info Center)
- Fix WAYLAND_DISPLAY in VM serial console for GUI app launching
- Add optional demo config with pre-assigned colors for screenshots

## Test plan

- [ ] VM: `./vm/launch-vm.sh --setup` launches all 8 apps without crash
- [ ] VM: `DEMO_CONFIG=true` applies colors to all apps
- [ ] Panel icon displays correctly (custom SVG, adapts to theme)
- [ ] About tab shows logo.svg
- [ ] README license badge shows GPL-2.0-or-later